### PR TITLE
feat: allow custom components per example

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,81 @@ Imports also work!
 ```
 ````
 
-## Options
+## Customization
 
-Examples can take additional options with each code block
+Examples can take various configurations. The defaults for all can be set in the remark plugin, but you can
+also provide them per-example as "meta" tags in the code block.
+
+```js
+{
+	remarkPlugins: [
+		[
+			examples,
+			{
+				defaults: {
+					foo: true,
+					bar: 'baz'
+				}
+			}
+		]
+	]
+}
+```
+
+````
+```svelte example foo bar="baz"
+
+...
+
+```
+````
+
+### Wrapper
+
+Example code blocks are rendered with a [Svelte component](./src/lib/Example.svelte). You can provide your own if you wish to customize its look or behaviour.
+
+```js
+{
+	remarkPlugins: [
+		[
+			examples,
+			{
+				defaults: {
+					Wrapper: '/src/lib/Example.svelte'
+				}
+			}
+		]
+	]
+}
+```
+
+When provided as code block meta, it can be relative to the file
+
+````
+```svelte example Wrapper="./Example.svelte"
+
+...
+
+```
+````
+
+```svelte
+<!-- src/lib/Example.svelte -->
+<script>
+	// the source of the example, if you want it
+	export let src
+
+	// all meta tags of the code block
+	export let meta
+</script>
+
+<div class="example">
+	<slot name="example" />
+</div>
+<div class="code">
+	<pre class="language-svelte"><slot name="code" /></pre>
+</div>
+```
 
 ### csr
 
@@ -155,35 +227,3 @@ the `src` prop if you have a custom Example component.
 </style>
 ```
 ````
-
-## Customization
-
-### Example component
-
-Examples (and the code block) are rendered with a [Svelte component](./src/lib/Example.svelte). You can provide your own if you wish to customize its look.
-
-```js
-import { defineMDSveXConfig as defineConfig } from 'mdsvex'
-import examples from 'mdsvexamples'
-
-const config = defineConfig({
-	remarkPlugins: [[examples, { ExampleComponent: '/src/lib/Example.svelte' }]]
-})
-
-export default config
-```
-
-```svelte
-<!-- src/lib/Example.svelte -->
-<script>
-	// the source of the example is provided as a prop if you want it
-	export let src
-</script>
-
-<div class="example">
-	<slot name="example" />
-</div>
-<div class="code">
-	<pre class="language-svelte"><slot name="code" /></pre>
-</div>
-```

--- a/src/routes/tests/meta/_Wrapper.svelte
+++ b/src/routes/tests/meta/_Wrapper.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let meta
+</script>
+
+{JSON.stringify(meta)}

--- a/src/routes/tests/meta/meta.spec.mjs
+++ b/src/routes/tests/meta/meta.spec.mjs
@@ -22,3 +22,10 @@ test('hideStyle', async ({ page }) => {
 	await expect(page.locator('text=<style>')).not.toBeVisible()
 	await expect(page.locator('button')).toHaveCSS('background-color', 'rgb(0, 0, 255)')
 })
+
+test('wrapper and custom meta', async ({ page }) => {
+	await page.goto('/tests/meta/wrapper')
+	await expect(
+		page.locator('text={"Wrapper":"./_Wrapper.svelte","example":true,"custom":["hello","world"]}')
+	).toBeVisible()
+})

--- a/src/routes/tests/meta/wrapper.svx
+++ b/src/routes/tests/meta/wrapper.svx
@@ -1,0 +1,3 @@
+```svelte example custom=["hello", "world"] Wrapper="./_Wrapper.svelte"
+
+```


### PR DESCRIPTION
provides a "Wrapper" config option to customize the component per example

"ExampleComponent" config has been renamed to "Wrapper"