### PR TITLE
Meta parsing correction

### DIFF
--- a/src/lib/remark.js
+++ b/src/lib/remark.js
@@ -99,7 +99,8 @@ export default function (options = {}) {
 
 function parseMeta(meta) {
   const result = {}
-  const meta_parts = meta.split(/ +(?=[\w]+=?)/g)
+  const meta_parts = meta.match(/(?:[^\s"]+|"[^"]*")+/g)
+  
 
   for (let i = 0; i < meta_parts.length; i++) {
     const [key, value = 'true'] = meta_parts[i].split('=')

--- a/src/lib/remark.js
+++ b/src/lib/remark.js
@@ -99,7 +99,7 @@ export default function (options = {}) {
 
 function parseMeta(meta) {
   const result = {}
-  const meta_parts = meta.match(/(?:[^\s"]+|"[^"]*")+/g)
+  const meta_parts = meta.match(/(?:[^\s"]+|"[^"]*")+/g) ?? []
   
 
   for (let i = 0; i < meta_parts.length; i++) {


### PR DESCRIPTION
Customization: meta tags example shows:
` ```svelte example foo bar="baz" `
and that works, but it will fail on:
` ```svelte example foo bar="baz with spaces" `

Working with `tailwindcss` you need the sequences of classes to be passed around and I need to pass them to my wrapper. So I need something like:
` ```svelte example class="text-center bg-red-300 inline-flex" `

Looking around, I've found:
https://stackoverflow.com/questions/16261635/javascript-split-string-by-space-but-ignore-space-in-quotes-notice-not-to-spli

That PR updates the `parseMeta` function with the ability to keep the quoted text together.
