### PR TITLE
feat: support named exports for wrapper components

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,10 @@ Example code blocks are rendered with a [Svelte component](./src/lib/Example.sve
       examples,
       {
         defaults: {
-          Wrapper: '/src/lib/Example.svelte'
+          Wrapper: '/src/lib/Example.svelte',
+
+          // or if the component is a named export
+          Wrapper: ['some-package', 'CustomExample'] // -> import { CustomExample } from 'some-package'
         }
       }
     ]

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,6 +1,7 @@
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
   testDir: './src/routes/tests',
+  timeout: 10000,
   webServer: {
     command: 'npm run build:site && npm run preview',
     port: 4173

--- a/src/lib/remark.js
+++ b/src/lib/remark.js
@@ -14,6 +14,9 @@ const RE_SCRIPT_START =
 const RE_SCRIPT_BLOCK = /(<script[\s\S]*?>)([\s\S]*?)(<\/script>)/g
 const RE_STYLE_BLOCK = /(<style[\s\S]*?>)([\s\S]*?)(<\/style>)/g
 
+// parses key=value pairs from a string. supports strings, numbers, booleans, and arrays
+const RE_PARSE_META = /(\w+=\d+|\w+="[^"]*"|\w+=\[[^\]]*\]|\w+)/g
+
 export const EXAMPLE_MODULE_PREFIX = '___mdsvexample___'
 export const EXAMPLE_COMPONENT_PREFIX = 'Mdsvexample___'
 
@@ -63,7 +66,10 @@ export default function (options = {}) {
     // add imports for each generated example
     let scripts = ''
     examples.forEach((example, i) => {
-      const imp = `import Example from "${example.Wrapper}";\n`
+      const imp =
+        typeof example.Wrapper === 'string'
+          ? `import Example from "${example.Wrapper}";\n`
+          : `import { ${example.Wrapper[1]} as Example } from "${example.Wrapper[0]}";\n`
 
       if (!scripts.includes(imp)) {
         scripts += imp
@@ -98,12 +104,18 @@ export default function (options = {}) {
 
 function parseMeta(meta) {
   const result = {}
-  const meta_parts = meta.match(/(?:[^\s"]+|"[^"]*")+/g) ?? []
+  const meta_parts = meta.match(RE_PARSE_META) ?? []
 
   for (let i = 0; i < meta_parts.length; i++) {
     const [key, value = 'true'] = meta_parts[i].split('=')
 
-    result[key] = JSON.parse(value)
+    try {
+      result[key] = JSON.parse(value)
+    } catch (e) {
+      const error = new Error(`Unable to parse meta \`${key}=${value}\` - ${e.message}`)
+      error.stack = e.stack
+      throw error
+    }
   }
 
   return result

--- a/src/routes/tests/meta/array/+page.svx
+++ b/src/routes/tests/meta/array/+page.svx
@@ -1,3 +1,3 @@
-```svelte example custom=["hello/world"] Wrapper="../Wrapper.svelte"
+```svelte example space=["hello", "world"] nospace=["hello","world"] Wrapper="../Wrapper.svelte"
 
 ```

--- a/src/routes/tests/meta/meta.spec.mjs
+++ b/src/routes/tests/meta/meta.spec.mjs
@@ -31,6 +31,8 @@ test('wrapper and custom meta', async ({ page }) => {
 test('array meta', async ({ page }) => {
   await page.goto('/tests/meta/array')
   await expect(
-    page.locator('text={"Wrapper":"../Wrapper.svelte","example":true,"custom":["hello/world"]}')
+    page.locator(
+      'text={"Wrapper":"../Wrapper.svelte","example":true,"space":["hello","world"],"nospace":["hello","world"]}'
+    )
   ).toBeVisible()
 })

--- a/src/routes/tests/meta/wrapper-named-export/+page.svx
+++ b/src/routes/tests/meta/wrapper-named-export/+page.svx
@@ -1,0 +1,3 @@
+```svelte example Wrapper=["../wrappers.js", "MetaWrapper"]
+
+```

--- a/src/routes/tests/meta/wrappers.js
+++ b/src/routes/tests/meta/wrappers.js
@@ -1,0 +1,3 @@
+import MetaWrapper from './Wrapper.svelte'
+
+export { MetaWrapper }


### PR DESCRIPTION
This adds support for a custom `Wrapper` when the component is a named export.

Via remark config:

```js
{
  remarkPlugins: [
    [
      examples,
      {
        defaults: {
          Wrapper: ['some-package', 'CustomExample'] // -> import { CustomExample } from 'some-package'
        }
      }
    ]
  ]
}
```

Via inline config:

````
```svelte example Wrapper=["some-package", "CustomExample"]

```
````
